### PR TITLE
fix: stale score updated on UI upon team switch

### DIFF
--- a/app/components/feedback.tsx
+++ b/app/components/feedback.tsx
@@ -8,6 +8,11 @@ interface PeerFeedbackProps {
     reportErrorStatus: (isError: boolean) => void,
 }
 
+type CategorizedFeedBack = {
+    independence: string;
+    technical: string;
+    teamwork: string;
+};
 
 export function PeerFeedback(props: PeerFeedbackProps) {
     const feedbackData = props.feedbackData;
@@ -35,8 +40,8 @@ export function PeerFeedback(props: PeerFeedbackProps) {
         peerFeedbackMap.set(feedback.week, weekFeedback);
     });
 
-    const strengthsByWeek = new Map<number, string[]>();
-    const areasOfGrowthByWeek = new Map<number, string[]>();
+    const strengthsByWeek = new Map<number, CategorizedFeedBack[]>();
+    const areasOfGrowthByWeek = new Map<number, CategorizedFeedBack[]>();
 
     const [errors, setErrors] = useState(new Map());
 
@@ -60,17 +65,28 @@ export function PeerFeedback(props: PeerFeedbackProps) {
         // feedback is a list of feedback objects for a given week
         // We want to aggregate across the areas of strength and weakness.
 
-        const strengths: string[] = [];
-        const areasOfGrowth: string[] = [];
-        feedback.forEach((f) => {
-            if (f.independenceContributions) strengths.push(f.independenceContributions);
-            if (f.technicalContributions) strengths.push(f.technicalContributions);
-            if (f.teamworkContributions) strengths.push(f.teamworkContributions);
-            if (f.independenceGrowth) areasOfGrowth.push(f.independenceGrowth);
-            if (f.technicalGrowth) areasOfGrowth.push(f.technicalGrowth);
-            if (f.teamworkGrowth) areasOfGrowth.push(f.teamworkGrowth);
-        });
+        const strengths: CategorizedFeedBack[] = []
+        const areasOfGrowth: CategorizedFeedBack[] = [];
 
+        feedback.forEach((f) => {
+            if (f.independenceContributions || f.technicalContributions || f.teamworkContributions) {
+                const strengthContribution: CategorizedFeedBack = {
+                    independence: f.independenceContributions || "",
+                    technical: f.technicalContributions || "",
+                    teamwork: f.teamworkContributions || "",
+                };
+                strengths.push(strengthContribution);
+            }
+            if (f.independenceGrowth || f.technicalGrowth || f.teamworkGrowth) {
+                const growthContribution: CategorizedFeedBack = {
+                    independence: f.independenceGrowth || "",
+                    technical: f.technicalGrowth || "",
+                    teamwork: f.teamworkGrowth || "",
+                };
+                areasOfGrowth.push(growthContribution);
+            }
+        });
+        
         strengthsByWeek.set(week, strengths);
         areasOfGrowthByWeek.set(week, areasOfGrowth);
     });
@@ -141,19 +157,49 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                         <strong>Week {i}</strong>
                         <div className="relative top-2 left-6">
                             <strong>Strengths</strong>
-                            <ul className="relative left-12">
-                                {
-                                    strengthsByWeek.get(i)?.map((strength, j) => <li key={"W" + i + "S" + j}>{strength}</li>)
-                                }
-                            </ul>
+                            {strengthsByWeek.get(i) && (
+                            <table className="table-auto border-collapse border border-gray-400 relative left-6">
+                                <thead>
+                                    <tr>
+                                        <th className="border border-gray-400 p-2">Independence</th>
+                                        <th className="border border-gray-400 p-2">Technical</th>
+                                        <th className="border border-gray-400 p-2">Teamwork</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {strengthsByWeek.get(i)?.map((strength, j) => (
+                                        <tr key={"W" + i + "S" + j}>
+                                            <td className="border border-gray-400 px-2 py-1">{strength.independence || "N/A"}</td>
+                                            <td className="border border-gray-400 px-2 py-1">{strength.technical || "N/A"}</td>
+                                            <td className="border border-gray-400 px-2 py-1">{strength.teamwork || "N/A"}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                            )}
                         </div>
                         <div className="relative top-2 left-6">
                             <strong>Areas of growth</strong>
-                            <ul className="relative left-12">
-                                {
-                                    areasOfGrowthByWeek.get(i)?.map((weakness, j) => <li key={"W" + i + "A" + j}>{weakness}</li>)
-                                }
-                            </ul>
+                            {areasOfGrowthByWeek.get(i) && (
+                            <table className="table-auto border-collapse border border-gray-400 relative left-6">
+                                <thead>
+                                    <tr>
+                                        <th className="border border-gray-400 p-2">Independence</th>
+                                        <th className="border border-gray-400 p-2">Technical</th>
+                                        <th className="border border-gray-400 p-2">Teamwork</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {areasOfGrowthByWeek.get(i)?.map((weakness, j) => (
+                                        <tr key={"W" + i + "A" + j}>
+                                            <td className="border border-gray-400 px-2 py-1">{weakness.independence || "N/A"}</td>
+                                            <td className="border border-gray-400 px-2 py-1">{weakness.technical || "N/A"}</td>
+                                            <td className="border border-gray-400 px-2 py-1">{weakness.teamwork || "N/A"}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                            )}
                         </div>
                         <div className="relative top-2 left-6">
                             <strong> TA comments</strong>

--- a/app/components/feedback.tsx
+++ b/app/components/feedback.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FeedbackLoaderData } from "~/services/server";
 
 
@@ -16,9 +16,8 @@ type CategorizedFeedBack = {
 
 export function PeerFeedback(props: PeerFeedbackProps) {
     const feedbackData = props.feedbackData;
-
+    
     const isAdmin = props.isAdmin;
-    const scores = feedbackData.scores;
     const currentWeek = Math.max(feedbackData.currentWeek, 0);
 
     const peerFeedbackMap = new Map<number, {
@@ -44,9 +43,19 @@ export function PeerFeedback(props: PeerFeedbackProps) {
     const areasOfGrowthByWeek = new Map<number, CategorizedFeedBack[]>();
 
     const [errors, setErrors] = useState(new Map());
+    const [scores, setScores] = useState(feedbackData.scores);
 
-    const handleScoreChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    useEffect(() => {
+        // Update scores state when feedbackData changes
+        setScores(feedbackData.scores);
+    }, [feedbackData]);
+
+    const handleScoreChange = (e: React.ChangeEvent<HTMLInputElement>, week: number, field: string) => {
         const value = Number(e.target.value);
+        const updateScores = scores.map((score) => {
+            return score.week === week ? {...score, [field]: value } : score;
+        });
+
         if (value < 0 || value > 5) {
             setErrors(new Map(errors.set(e.target.name, "Scores must be between 0 and 5")));
             props.reportErrorStatus(true);
@@ -58,6 +67,7 @@ export function PeerFeedback(props: PeerFeedbackProps) {
             }
             setErrors(new Map(errors));
         }
+        setScores(updateScores);
     };
 
     // Aggregate strengths and areas of growth by week
@@ -120,16 +130,16 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                                     <td>{score.week}</td>
                                     <td>{isAdmin ?
                                         <input name={"I" + feedbackData.userID + "W" + score.week}
-                                            defaultValue={score.independence != null ? score.independence : ""}
-                                            onChange={handleScoreChange} />
+                                            value={score.independence != null ? score.independence : ""}
+                                            onChange={(e) => handleScoreChange(e, score.week, "independence")} />
                                         : score.independence}
                                         {errors.get("I" + feedbackData.userID + "W" + score.week) ? validationError : <></>}
                                     </td>
                                     <td>
                                         {isAdmin ?
                                             <input name={"T" + feedbackData.userID + "W" + score.week}
-                                                defaultValue={score.technical != null ? score.technical : ""}
-                                                onChange={handleScoreChange} />
+                                                value={score.technical != null ? score.technical : ""}
+                                                onChange={(e) => handleScoreChange(e, score.week, "technical")} />
                                             : score.technical}
                                         {errors.get("T" + feedbackData.userID + "W" + score.week) ? validationError : <></>}
 
@@ -137,8 +147,8 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                                     <td>
                                         {isAdmin ?
                                             <input name={"W" + feedbackData.userID + "W" + score.week}
-                                                defaultValue={score.teamwork != null ? score.teamwork : ""}
-                                                onChange={handleScoreChange} />
+                                                value={score.teamwork != null ? score.teamwork : ""}
+                                                onChange={(e) => handleScoreChange(e, score.week, "teamwork")} />
                                             : score.teamwork}
                                         {errors.get("W" + feedbackData.userID + "W" + score.week) ? validationError : <></>}
                                     </td>

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -28,4 +28,8 @@
     input {
         @apply border
     }
+
+    textarea {
+        @apply border
+    }
 }


### PR DESCRIPTION
Currently, if a score is entered for a student in a team (but not saved), and the team is changed, the stale score from the previous student is still displayed for the new team (vanishes when the page is refreshed, implying that the database operations are ok).

Fix : 
- attached a _state_ to the scores and a `useEffect` that triggers whenever the props are updated
- replaced `defaultValue` with `value` in the table
- updated `handleScoreChange` method to update the state accordingly.

Should fix #11. 