### PR TITLE
feat: made start stop continue fields visible

### DIFF
--- a/app/components/weeklyReport.tsx
+++ b/app/components/weeklyReport.tsx
@@ -1,0 +1,68 @@
+import { WeeklyReportLoaderData } from "~/services/server";
+
+
+interface WeeklyReportProps {
+    weeklyReportData: WeeklyReportLoaderData["teamFeedback"],
+    isAdmin: boolean,
+}
+
+export function WeeklyReports(props: WeeklyReportProps) {
+    const reports = props.weeklyReportData;
+    const isAdmin = props.isAdmin;
+
+
+    // Group reports by week
+    const weeklyReportMap = new Map<number, {
+        authorID: number,
+        author: string,
+        continueDoing: string | null,
+        startDoing: string | null,
+        stopDoing: string | null,
+        contributions: string | null,
+        challenges: string | null,
+    }[]>();
+
+    reports.forEach((report) => {
+        let weeklyReport = weeklyReportMap.get(report.week);
+        if (!weeklyReport) {
+            weeklyReport = [];
+        }
+        weeklyReport.push(report)
+        weeklyReportMap.set(report.week, weeklyReport);
+    });
+    
+
+  return (
+    <div className="container mx-auto p-4">
+      {Array.from(weeklyReportMap.entries()).map(([week, weeklyReport]) => (
+        <div key={week} className="mb-8">
+          <h2 className="text-xl font-bold mb-4">Week {week}</h2>
+          <table className="table-auto border-collapse border border-gray-400 w-full">
+            <thead>
+              <tr>
+                {isAdmin && <th className="border border-gray-400 p-2">Team Member</th>}
+                <th className="border border-gray-400 p-2">Start Doing</th>
+                <th className="border border-gray-400 p-2">Stop Doing</th>
+                <th className="border border-gray-400 p-2">Continue Doing</th>
+                <th className="border border-gray-400 p-2">Contributions</th>
+                <th className="border border-gray-400 p-2">Challenges</th>
+              </tr>
+            </thead>
+            <tbody>
+              {weeklyReport.map((report) => (
+                <tr key={`${week}-${report.authorID}`}>
+                  {isAdmin && <td className="border border-gray-400 p-2">{report.author}</td>}
+                  <td className="border border-gray-400 p-2">{report.startDoing || "-"}</td>
+                  <td className="border border-gray-400 p-2">{report.stopDoing || "-"}</td>
+                  <td className="border border-gray-400 p-2">{report.continueDoing || "-"}</td>
+                  <td className="border border-gray-400 p-2">{report.contributions || "-"}</td>
+                  <td className="border border-gray-400 p-2">{report.challenges || "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/services/server.ts
+++ b/app/services/server.ts
@@ -44,6 +44,20 @@ export type FeedbackLoaderData = {
     }[]
 };
 
+export type WeeklyReportLoaderData = {
+    teamFeedback: {
+        author: string,
+        authorID: number,
+        week: number,
+        continueDoing: string | null,
+        startDoing: string | null,
+        stopDoing: string | null,
+        contributions: string | null,
+        challenges: string | null,
+    }[],
+}
+
+
 export async function getUserFeedback(userID: number) : Promise<FeedbackLoaderData> {
     const prisma = new PrismaClient();
 
@@ -99,4 +113,31 @@ export async function getUserFeedback(userID: number) : Promise<FeedbackLoaderDa
         scores: finalScores,
         peerFeedback: peerFeedback
     };
+}
+
+export async function getWeeklyReport() : Promise<WeeklyReportLoaderData> {
+    const prisma = new PrismaClient();
+
+    const weeklyReports = await prisma.weeklyReport.findMany({
+        orderBy: {
+          week: "asc",
+        },
+      });
+    
+      const users = await prisma.user.findMany({
+        select: { id: true, name: true }, 
+      });
+    
+      const userMap: Record<number, string> = {};
+
+      for (const user of users) {
+        userMap[user.id] = user.name;
+      }
+
+      const reports = weeklyReports.map((report) => ({
+        ...report,
+        author: userMap[report.authorID], // Fallback for missing users
+      }));
+    
+      return { teamFeedback: reports };
 }


### PR DESCRIPTION
Made `startDoing`, `stopDoing`, `continueDoing`, `contributions` and `challenges` fields from Weekly Team Reports visible on the staff view along with commenter name (hidden in student view).

Should fix #16.