### PR TITLE
feat(ui): empty weeks erased, table widths adjusted

### DIFF
--- a/app/components/feedback.tsx
+++ b/app/components/feedback.tsx
@@ -119,6 +119,15 @@ export function PeerFeedback(props: PeerFeedbackProps) {
         areasOfGrowthByWeek.set(week, areasOfGrowth);
     });
 
+    //find the first week for which data is not empty (before the current week) else return current week onwards
+    const getFirstKeyAsInt = (map: Map<number, CategorizedFeedBack[]>) => {
+        const firstEntry = map.entries().next().value;
+        return firstEntry ? parseInt(firstEntry[0], 10) : currentWeek;
+    };
+    
+    const ind1 = getFirstKeyAsInt(strengthsByWeek);
+    const ind2 = getFirstKeyAsInt(areasOfGrowthByWeek);
+    const firstWeek = Math.min(ind1, ind2);
     const validationError = <div className="text-red-600">Values must be between 0 and 5.</div>;
 
     let currentComments = scores.find((score) => score.week == currentWeek)?.comments ? scores.find((score) => score.week == currentWeek)?.comments : "";
@@ -180,7 +189,7 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                 <strong>TA comments, week {currentWeek}:</strong>
                 <p /><textarea name={"currentWeekComments" + feedbackData.userID + "W" + currentWeek} className="h-32 w-full" defaultValue={currentComments} />
 
-                {new Array(currentWeek + 1).fill(0).map((_, i) =>
+                {new Array(currentWeek + 1).fill(0).map((_, i) => i>=firstWeek &&
                     <div key={i} className="relative top-6 p-2">
                         <strong>Week {i}</strong>
                         <div className="relative top-2 left-6">
@@ -198,10 +207,10 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                                 <tbody>
                                     {strengthsByWeek.get(i)?.map((strength, j) => (
                                         <tr key={"W" + i + "S" + j}>
-                                            {isAdmin && (<td className="border border-gray-400 px-2 py-1">{strength.byUserName}</td>)}
-                                            <td className="border border-gray-400 px-2 py-1">{strength.independence}</td>
-                                            <td className="border border-gray-400 px-2 py-1">{strength.technical}</td>
-                                            <td className="border border-gray-400 px-2 py-1">{strength.teamwork}</td>
+                                            {isAdmin && (<td className="border border-gray-400 px-2 py-1 w-48 break-words">{strength.byUserName}</td>)}
+                                            <td className="border border-gray-400 px-2 py-1 w-80 break-words">{strength.independence}</td>
+                                            <td className="border border-gray-400 px-2 py-1 w-80 break-words">{strength.technical}</td>
+                                            <td className="border border-gray-400 px-2 py-1 w-80 break-words">{strength.teamwork}</td>
                                         </tr>
                                     ))}
                                 </tbody>
@@ -211,7 +220,7 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                         <div className="relative top-2 left-6">
                             <strong>Areas of growth</strong>
                             {areasOfGrowthByWeek.get(i) && (
-                            <table className="table-auto border-collapse border border-gray-400 relative left-6">
+                            <table className="table-auto border-collapse border border-gray-400 relative  left-6">
                                 <thead>
                                     <tr>
                                         {isAdmin && (<th className="border border-gray-400 p-2">Team Member</th>)}
@@ -223,10 +232,10 @@ export function PeerFeedback(props: PeerFeedbackProps) {
                                 <tbody>
                                     {areasOfGrowthByWeek.get(i)?.map((weakness, j) => (
                                         <tr key={"W" + i + "A" + j}>
-                                            {isAdmin && (<td className="border border-gray-400 px-2 py-1">{weakness.byUserName}</td>)}
-                                            <td className="border border-gray-400 px-2 py-1">{weakness.independence}</td>
-                                            <td className="border border-gray-400 px-2 py-1">{weakness.technical}</td>
-                                            <td className="border border-gray-400 px-2 py-1">{weakness.teamwork}</td>
+                                            {isAdmin && (<td className="border border-gray-400 px-2 py-1 w-48 break-words">{weakness.byUserName}</td>)}
+                                            <td className="border border-gray-400 px-2 py-1 w-80 break-words">{weakness.independence}</td>
+                                            <td className="border border-gray-400 px-2 py-1 w-80 break-words">{weakness.technical}</td>
+                                            <td className="border border-gray-400 px-2 py-1 w-80 break-words">{weakness.teamwork}</td>
                                         </tr>
                                     ))}
                                 </tbody>

--- a/app/components/weeklyReport.tsx
+++ b/app/components/weeklyReport.tsx
@@ -31,13 +31,14 @@ export function WeeklyReports(props: WeeklyReportProps) {
         weeklyReportMap.set(report.week, weeklyReport);
     });
     
+    console.log(reports);
 
   return (
-    <div className="container mx-auto p-4">
+    <div className="relative top-2">
       {Array.from(weeklyReportMap.entries()).map(([week, weeklyReport]) => (
         <div key={week} className="mb-8">
           <h2 className="text-xl font-bold mb-4">Week {week}</h2>
-          <table className="table-auto border-collapse border border-gray-400 w-full">
+          <table className="table-auto border-collapse border border-gray-400 relative">
             <thead>
               <tr>
                 {isAdmin && <th className="border border-gray-400 p-2">Team Member</th>}
@@ -51,12 +52,12 @@ export function WeeklyReports(props: WeeklyReportProps) {
             <tbody>
               {weeklyReport.map((report) => (
                 <tr key={`${week}-${report.authorID}`}>
-                  {isAdmin && <td className="border border-gray-400 p-2">{report.author}</td>}
-                  <td className="border border-gray-400 p-2">{report.startDoing || "-"}</td>
-                  <td className="border border-gray-400 p-2">{report.stopDoing || "-"}</td>
-                  <td className="border border-gray-400 p-2">{report.continueDoing || "-"}</td>
-                  <td className="border border-gray-400 p-2">{report.contributions || "-"}</td>
-                  <td className="border border-gray-400 p-2">{report.challenges || "-"}</td>
+                  {isAdmin && <td className="border border-gray-400 px-2 py-1 w-48 break-words">{report.author}</td>}
+                  <td className="border border-gray-400 px-2 py-1 w-64 break-words">{report.startDoing || "-"}</td>
+                  <td className="border border-gray-400 px-2 py-1 w-64 break-words">{report.stopDoing || "-"}</td>
+                  <td className="border border-gray-400 px-2 py-1 w-64 break-words">{report.continueDoing || "-"}</td>
+                  <td className="border border-gray-400 px-2 py-1 w-64 break-words">{report.contributions || "-"}</td>
+                  <td className="border border-gray-400 px-2 py-1 w-64 break-words">{report.challenges || "-"}</td>
                 </tr>
               ))}
             </tbody>

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -75,12 +75,20 @@ export default function Layout() {
             background: 'rgba(0, 0, 0, 0.3)'
         }
     }
+    const loginStyles = {
+        padding: '0.5em',
+        border: '1px solid black',
+        borderRadius: '10px', 
+        fontSize: 'large'
+    }
 
     const user = useOptionalUser();
 
     if (!user) {
-        return (<div>< Link to="/login" > Log In</Link ></div>);
+        return (<div style={{margin: '2em', justifySelf: 'center'}}>< Link to="/login" style={loginStyles}> Log In</Link ></div>);
     }
+
+
 
     const isAdmin = user?.isAdmin;
 
@@ -102,11 +110,11 @@ export default function Layout() {
                             < p > <Link to="/feedback" className="menu-item" >My feedback</Link></p>
                         </>
                     }
-                    <p>
-                        <Form method="post" action="/logout">
-                            <button type="submit">Log Out</button>
+                    <>
+                        <Form method="post" action="/logout" style={{margin: '2em', justifySelf: 'center'}}>
+                            <button type="submit" style={loginStyles}>Log Out</button>
                         </Form>
-                    </p>
+                    </>
                 </Slide>
             </div >
 

--- a/app/routes/_layout.tsx
+++ b/app/routes/_layout.tsx
@@ -1,5 +1,5 @@
 import {Form, Link, Outlet } from "@remix-run/react";
-
+import { loginStyles } from "./login";
 import { useOptionalUser } from "../utils";
 
 import pkg from 'react-burger-menu';
@@ -75,13 +75,6 @@ export default function Layout() {
             background: 'rgba(0, 0, 0, 0.3)'
         }
     }
-    const loginStyles = {
-        padding: '0.5em',
-        border: '1px solid black',
-        borderRadius: '10px', 
-        fontSize: 'large'
-    }
-
     const user = useOptionalUser();
 
     if (!user) {

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,5 +1,6 @@
 import { Form } from "@remix-run/react";
-const loginStyles = {
+
+export const loginStyles = {
     padding: '0.5em',
     border: '1px solid black',
     borderRadius: '10px', 

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,10 +1,15 @@
 import { Form } from "@remix-run/react";
-
+const loginStyles = {
+    padding: '0.5em',
+    border: '1px solid black',
+    borderRadius: '10px', 
+    fontSize: 'large'
+}
 export default function Login() {
     return (
         <div>
-            <Form action="/auth/google" method="post">
-                <button>Login with Google</button>
+            <Form action="/auth/google" method="post" style={{margin: '2em', justifySelf: 'center'}}>
+                <button style={loginStyles}>Login with Google</button>
             </Form>
         </div>
     )


### PR DESCRIPTION
- The feedback view now starts displaying from the _first week with available data_, skipping weeks without any entries.
- Updated the tables to have a _fixed width_ and _wrap text_ to avoid overflow
- Updated _login and logout button styles_ (received feedback from students that it was very small and in the top left corner, making it difficult to find in the first go)